### PR TITLE
Modificación de controls y main.py

### DIFF
--- a/amigo_dialog.py
+++ b/amigo_dialog.py
@@ -30,7 +30,7 @@ class AmigoDialog(wx.Dialog):
 		for criterio in self.lista_puntuaciones:
 			# Se muestra el texto del criterio tal como aparece en el archivo
 			wx.StaticText(self.panel, label=criterio + ":")
-			ctrl = wx.TextCtrl(self.panel)
+			ctrl = wx.SpinCtrl(self.panel, value="0", min=0, max=10)
 			self.puntuaciones_ctrls[criterio] = ctrl
 			self.main_sizer.Add(ctrl, 0, wx.EXPAND | wx.ALL, 5)
 		

--- a/main.py
+++ b/main.py
@@ -222,6 +222,13 @@ class AmigosApp(wx.Frame):
 def main():
 	# Se inicializa la aplicación de wxPython primero para poder mostrar mensajes con wx.MessageBox.
 	app = wx.App()
+	# Verificar si ya hay una instancia ejecutándose
+	name = "manage-friends-Instance"  # Identificador para la aplicación
+	instance = wx.SingleInstanceChecker(name)
+	if instance.IsAnotherRunning():
+		wx.MessageBox("el gestor de amistades ya está en ejecución.", "Aviso", wx.ICON_INFORMATION)
+		return False
+
 
 	criterios, hubo_problema = cargar_criterios()
 

--- a/reevaluar_amigo_dialog.py
+++ b/reevaluar_amigo_dialog.py
@@ -50,7 +50,7 @@ class ReevaluarAmigoDialog(wx.Dialog):
 			self.lista_puntuaciones = criterios
 		for clave in self.lista_puntuaciones:
 			wx.StaticText(self.panel, label=clave + ":")
-			ctrl = wx.TextCtrl(self.panel)
+			ctrl = wx.SpinCtrl(self.panel, value="0", min=0, max=10)
 			self.puntuaciones_ctrls[clave] = ctrl
 			self.main_sizer.Add(ctrl, 0, wx.EXPAND | wx.ALL, 5)
 		
@@ -141,7 +141,7 @@ class ReevaluarAmigoDialog(wx.Dialog):
 		if cur_gen != self.original_genero:
 			return True
 		for clave, ctrl in self.puntuaciones_ctrls.items():
-			if ctrl.GetValue().strip() != self.original_puntuaciones.get(clave, ""):
+			if ctrl.GetValue() != self.original_puntuaciones.get(clave, ""):
 				return True
 		return False
 	
@@ -158,7 +158,7 @@ class ReevaluarAmigoDialog(wx.Dialog):
 			nuevas_puntuaciones = {}
 			for clave, ctrl in self.puntuaciones_ctrls.items():
 				try:
-					valor = int(ctrl.GetValue())
+					valor  =ctrl.GetValue()
 				except ValueError:
 					raise ValueError(f"El valor de '{clave}' debe ser un número entero.")
 				nuevas_puntuaciones[clave] = valor


### PR DESCRIPTION
Se ha eliminado el control TextCtrl, en su lugar se ha puesto SpinCtrl. Esto evita que se ponga texto en el cuadro, ya que el mismo lanza un mensaje de información. También se añadió una validación en main.py, para evitar instancias duplicadas de la aplicación